### PR TITLE
fix(input): allow binary strings with arbitrary spacing (#2)

### DIFF
--- a/ctftools.tests/Format/Binary.cs
+++ b/ctftools.tests/Format/Binary.cs
@@ -11,9 +11,44 @@ namespace ctftools.tests.Format
         [Theory]
         [InlineData("01100110 01101100 01100001 01100111 01111011 00110001 00110010 00110011 01111101")]
         [InlineData("011001100110110001100001011001110111101100110001001100100011001101111101")]
+        [InlineData("0110 0110 0110 1100 0110 0001 0110 0111 0111 1011 0011 0001 0011 0010 0011 0011 0111 1101")]
+        [InlineData("0 1 1 0 0 1 1 0 0 1 1 0 1 1 0 0 0 1 1 0 0 0 0 1 0 1 1 0 0 11 1 0 1 1 1 1 0 1 1 0 0 1 1 0 0 0 1 0 0 1 1 0 0 1 0 0 0 1 1 0 0 1 1 0 1 1 1 1 1 0 1 ")]
         public void ToTextShouldConvertBinaryStringToText(string flag)
         {
             Assert.Equal("flag{123}", ctftools.Format.Binary.ToText(flag));
+        }
+
+        [Fact]
+        public void ToText_ShouldReturnEmpty_ForEmptyOrWhitespace()
+        {
+            Assert.Equal(string.Empty, ctftools.Format.Binary.ToText(string.Empty));
+            Assert.Equal(string.Empty, ctftools.Format.Binary.ToText(" "));
+            Assert.Equal(string.Empty, ctftools.Format.Binary.ToText("\t\n"));
+        }
+
+        [Fact]
+        public void ToText_ShouldThrowArgumentNullException_ForNull()
+        {
+            Assert.Throws<ArgumentNullException>(() => ctftools.Format.Binary.ToText(null));
+        }
+
+        [Theory]
+        [InlineData("01010201")]
+        [InlineData("01A01010")]
+        [InlineData("2010")]
+        public void ToText_ShouldThrowArgumentException_ForNonBinaryCharacters(string input)
+        {
+            Assert.Throws<ArgumentException>(() => ctftools.Format.Binary.ToText(input));
+        }
+
+        [Theory]
+        [InlineData("0")]
+        [InlineData("010")]
+        [InlineData("0100100001")] //10 bits
+        [InlineData("01001000010")] // mixed with space, still not multiple of8
+        public void ToText_ShouldThrowArgumentException_ForInvalidLength(string input)
+        {
+            Assert.Throws<ArgumentException>(() => ctftools.Format.Binary.ToText(input));
         }
     }
 }

--- a/src/Format/Binary.cs
+++ b/src/Format/Binary.cs
@@ -5,21 +5,31 @@ public class Binary
 {
     public static string ToText(string inputBytes)
     {
-        var bytes = inputBytes.Split(" ");
-        bool addSpace = bytes.Length == 1 && inputBytes.Length != 8;
+        if (inputBytes is null)
+            throw new ArgumentNullException(nameof(inputBytes));
 
-        StringBuilder result = new StringBuilder();
-        for (int i = 0; i < inputBytes.Length; i++)
+        if (string.IsNullOrWhiteSpace(inputBytes))
+            return string.Empty;
+
+        var bits = new string(inputBytes.Where(c => !char.IsWhiteSpace(c)).ToArray());
+
+        if(bits.Length == 0)
+            return string.Empty;
+
+        if(bits.Any(c => c!='0' && c!='1'))
+            throw new ArgumentException("Input string is not a valid binary string.");
+
+        if (bits.Length % 8 != 0)
+            throw new ArgumentException("Input length must be a multiple of 8 after removing whitespace.", nameof(inputBytes));
+
+        var result = new StringBuilder(bits.Length / 8);
+        for (int i = 0; i < bits.Length; i += 8)
         {
-            if (addSpace && i % 8 == 0)
-            {
-                result.Append(" ");
-            }
-            result.Append(inputBytes[i]);
+            var byteString = bits.Substring(i, 8);
+            int value = Convert.ToInt32(byteString, 2);
+            result.Append(Convert.ToChar(value));
         }
 
-        return string.Concat(result.ToString().Split(" ")
-            .Where(bin => !string.IsNullOrEmpty(bin))
-            .Select(bin => Convert.ToChar(Convert.ToInt32(bin, 2))));
+        return result.ToString();
     }
 }


### PR DESCRIPTION
Strip spaces from binary string inputs before processing so both compact ("01100110...") and spaced formats ("0110 0110 ..." or even "0 1 1 0 ...") are accepted. This broadens test coverage and prevents false negatives for differently formatted inputs.